### PR TITLE
feat: #CERTUTF-0 Pegar credencias do application.properties como base…

### DIFF
--- a/src/main/java/com/ms/uploader/api/controllers/ImageController.java
+++ b/src/main/java/com/ms/uploader/api/controllers/ImageController.java
@@ -48,7 +48,7 @@ public class ImageController {
     )
 
     @PostMapping
-    public ImageDTO upload( @RequestParam("file") MultipartFile multipartFile ) {
-        return imageService.upload(multipartFile);
+    public ImageDTO upload( @RequestParam("file") MultipartFile multipartFile, @RequestParam("identifier") String identifier ) {
+        return imageService.upload(multipartFile, identifier);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,9 +3,10 @@ server.port=5055
 
 eureka.instance.instance-id=${spring.application.name}:${spring.application.instance_id:${random.value}}
 
-firebase.private.key.path=${FIREBASE_PRIVATE_KEY_PATH}
 firebase.bucket=${FIREBASE_BUCKET}
 firebase.download.url="${FIREBASE_DOWNLOAD_URL}"
 
 eureka.client.service-url.defaultZone=${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
 eureka.client.fetch-registry=true
+
+google.cloud.storage.credentials=${GOOGLE_CLOUD_STORAGE_CREDENTIALS}


### PR DESCRIPTION
Pegar credencias do application.properties como base64, ao invés de converter de um arquivo .json. Receber identificador da image, para ser possível substituir ou versionar no cloud storage.